### PR TITLE
Improve memory footprint for n‑gram lookup tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@ Note: This project was developed in Python 3.13. Older versions may work but hav
 Run the main script from the shell to decrypt the provided ciphertext using the provided word list:
 
 ```bash
-python main.py WORD-LIST CIPHERTEXT
+python main.py [-h] [-w WORDLIST] ciphertext
 ```
 
-- `WORD-LIST`: Path to a word-frequency list (e.g., `data/word-list/eng-gb.txt`).
-- `CIPHERTEXT`: Path to a ciphertext file (e.g., `data/ciphertext/morland-page01.txt`). Tokens in the ciphertext file should be separated by spaces to detect multi-character tokens. Line breaks are treated as spaces but otherwise do not matter.
+- `WORDLIST`: Path to a word-frequency list (default `data/word-list/eng-gb.txt`).
+- `ciphertext`: Path to a ciphertext file (e.g., `data/ciphertext/morland-page01.txt`). Tokens in the ciphertext file should be separated by spaces to detect multi-character tokens. Line breaks are treated as spaces but otherwise do not matter.
 
 ## Example
 
 ```bash
-python main.py data/word-list/eng-gb.txt data/ciphertext/morland-page01.txt
+python main.py data/ciphertext/morland-page01.txt
 ```
 
 ## Method
@@ -105,7 +105,7 @@ O  0.077
 I  0.074
 ```
 
-We can also do this for combinations of two letters (bigrams):
+This shows that about one in every eight letters of English text is an "E". We can also do this for combinations of two letters (bigrams):
 
 ```text
 TH  0.038
@@ -146,7 +146,7 @@ N L   -1.490    N E   -0.286
 Mean  -0.953    Mean   0.435 
 ```
 
-The right-hand side has the higher total, so the transition 1→4 is more likely than transition 1→2.
+The right-hand side has the higher mean score, so the transition 1→4 is more likely than transition 1→2.
 
 We can repeat this process for all possible transitions to build a matrix where larger numbers indicate more likely transitions.
 

--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ def score_column_pair(
     i: int,
     j: int,
     alternate: bool = False,
-):
+) -> float:
     global context
     assert context is not None
 
@@ -84,7 +84,7 @@ def score_column_pair(
                 total += value
                 count += 1
 
-    return total / count if count > 0 else 0
+    return total / count if count > 0 else 0.0
 
 
 def score_sequence(text: Sequence[str], m: int) -> float:

--- a/main.py
+++ b/main.py
@@ -169,6 +169,7 @@ def main() -> None:
             sort_keys=True,
         )
     )
+    print(f"Results saved to {path.name}")
 
 
 def init_worker(args: argparse.Namespace) -> None:

--- a/ngram.py
+++ b/ngram.py
@@ -38,7 +38,14 @@ def log_expected(n: int) -> dict[NGram, float]:
 
 @functools.cache
 def log_observed(n: int) -> dict[NGram, float]:
-    counts = ngram_count(n)
+    counts = collections.defaultdict(int)
+
+    with open(WORD_LIST, encoding="utf-8") as file:
+        for line in file:
+            word, count = line.split(maxsplit=1)
+            for ngram in sliding_window(word, n):
+                counts[ngram] += int(count)
+
     log_total = math.log(sum(counts.values()))
 
     return {
@@ -53,16 +60,3 @@ def log_observed_expected(n: int) -> dict[NGram, float]:
     log_exp = log_expected(n)
 
     return {ngram: (log_obs[ngram] - log_exp[ngram]) for ngram in log_obs}
-
-
-@functools.cache
-def ngram_count(n: int) -> dict[NGram, int]:
-    result = collections.defaultdict(int)
-
-    with open(WORD_LIST, encoding="utf-8") as file:
-        for line in file:
-            word, count = line.split(maxsplit=1)
-            for ngram in sliding_window(word, n):
-                result[ngram] += int(count)
-
-    return dict(result)

--- a/ngram.py
+++ b/ngram.py
@@ -1,16 +1,12 @@
-import collections
-import functools
+import array
 import itertools
 import math
 import string
-import sys
 from collections import deque
-from typing import Iterable, Iterator, TypeVar
+from typing import Iterable, Iterator, Mapping, Sequence, TypeVar
 
 type NGram = tuple[str, ...]
 T = TypeVar("T")
-
-WORD_LIST = sys.argv[1]
 
 
 def sliding_window(iterable: Iterable[T], n: int) -> Iterator[tuple[T, ...]]:
@@ -24,39 +20,65 @@ def sliding_window(iterable: Iterable[T], n: int) -> Iterator[tuple[T, ...]]:
         yield tuple(window)
 
 
-@functools.cache
-def log_expected(n: int) -> dict[NGram, float]:
-    log_obs = log_observed(1)
-    all_ngrams = itertools.product(string.ascii_uppercase, repeat=n)
+class NGramTable(Mapping[NGram, float]):
+    def __init__(self, n: int, data: Sequence[float]) -> None:
+        if len(data) != 26**n:
+            raise ValueError(f"data must have 26**{n} elements")
 
-    result: dict[NGram, float] = {}
-    for ngram in all_ngrams:
-        result[ngram] = sum(log_obs.get((ch,), 0.0) for ch in ngram)
+        self._n = n
+        self._data = data
 
-    return result
+    def __len__(self) -> int:
+        return 26**self._n
+
+    def __getitem__(self, key: NGram) -> float:
+        return self._data[encode(key)]
+
+    def __iter__(self) -> Iterator[NGram]:
+        return itertools.product(string.ascii_uppercase, repeat=self._n)
 
 
-@functools.cache
-def log_observed(n: int) -> dict[NGram, float]:
-    counts = collections.defaultdict(int)
+def encode(key: NGram) -> int:
+    idx = 0
+    for c in key:
+        idx = idx * 26 + (ord(c) - 65)
 
-    with open(WORD_LIST, encoding="utf-8") as file:
-        for line in file:
-            word, count = line.split(maxsplit=1)
-            for ngram in sliding_window(word, n):
-                counts[ngram] += int(count)
+    return idx
 
-    log_total = math.log(sum(counts.values()))
 
-    return {
-        ngram: (math.log(ngram_count) - log_total)
-        for ngram, ngram_count in counts.items()
+def load_tables(seq: Iterable[str]) -> dict[int, NGramTable]:
+    gram_count: dict[int, array.array] = {
+        n: array.array("Q", (0 for _ in range(26**n))) for n in (1, 2, 3, 5)
     }
 
+    for line in seq:
+        word, count_str = line.split(maxsplit=1)
+        count = int(count_str)
+        for n, table in gram_count.items():
+            for ngram in sliding_window(word, n):
+                table[encode(ngram)] += count
 
-@functools.cache
-def log_observed_expected(n: int) -> dict[NGram, float]:
-    log_obs = log_observed(n)
-    log_exp = log_expected(n)
+    log_totals = {n: math.log(sum(table)) for n, table in gram_count.items()}
 
-    return {ngram: (log_obs[ngram] - log_exp[ngram]) for ngram in log_obs}
+    log_observed_1 = array.array(
+        "f", (math.log(x) - log_totals[1] if x > 0 else math.nan for x in gram_count[1])
+    )
+
+    log_observed_expected: dict[int, array.array] = {}
+    for n, table in gram_count.items():
+        if n == 1:
+            continue
+
+        all_indices = itertools.product(range(26), repeat=n)
+
+        values = (
+            (
+                math.log(x) - log_totals[n] - sum(log_observed_1[ch] for ch in gram)
+                if x > 0
+                else math.nan
+            )
+            for x, gram in zip(table, all_indices)
+        )
+        log_observed_expected[n] = array.array("f", values)
+
+    return {n: NGramTable(n, log_observed_expected[n]) for n in log_observed_expected}


### PR DESCRIPTION
Create a custom data structure for n‑gram lookup tables.

Previously, the lookup tables were implemented as Python dictionaries with:

- **Keys:** n‑tuples of single‑character strings
- **Values:** 64‑bit floats

For 5‑grams, this results in $26^5$ = approx 12 million entries. Each process has its own copy, leading to a memory footprint of roughly 1 GiB per process.

This PR replaces that structure with a single `array.array` of 32‑bit floats. Each n‑gram is encoded directly as an integer index into the array. This reduces the memory footprint to about 48 MiB per process.

Additional changes:
- Switched from `sys.argv` to `argparse` for more flexible CLI handling and to support adding another solver in a future PR.
- Corrected the return type of `find_best_key`.
- Minor wording improvements in the README.