### PR TITLE
Add CP-SAT solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,28 @@ cd morland-cipher
 pip install -r requirements.txt
 ```
 
-Note: This project was developed in Python 3.13. Older versions may work but have not been checked.
+**Note:** This project was developed in Python 3.13. Older versions may work but have not been checked.
 
 ## Usage
 
-Run the main script from the shell to decrypt the provided ciphertext using the provided word list:
+Run the main script to recover likely plaintexts from a ciphertext file:
 
 ```bash
-python main.py [-h] [-w WORDLIST] ciphertext
+python main.py [-h] [-s {routing,cp-sat}] [-w WORDLIST] ciphertext
 ```
 
-- `WORDLIST`: Path to a word-frequency list (default `data/word-list/eng-gb.txt`).
-- `ciphertext`: Path to a ciphertext file (e.g., `data/ciphertext/morland-page01.txt`). Tokens in the ciphertext file should be separated by spaces to detect multi-character tokens. Line breaks are treated as spaces but otherwise do not matter.
+- `-s {routing,cp-sat}`: Select the TSP solver (default: `routing`)
+  - `routing`: OR-Tools Routing Library. Fast, but approximate.
+  - `cp-sat`: CP-SAT. Slower, but more thorough.
+- `-w WORDLIST`: Path to a word-frequency list (default: `data/word-list/eng-gb.txt`).
+- `ciphertext`: Path to the ciphertext file (e.g., `data/ciphertext/morland-page01.txt`).
 
-## Example
+Notes on ciphertext format:
+
+- Tokens must be separated by spaces to detect multi-character tokens.
+- Line breaks are treated as spaces and otherwise ignored.
+
+## Minimal Example
 
 ```bash
 python main.py data/ciphertext/morland-page01.txt
@@ -217,7 +225,7 @@ Now that we have an approach for determining the most likely key for each (numbe
 
 ## Bibliography
 
-- Furnon, Vincent, and Laurent Perron. *OR-Tools Routing Library*. Version 9.14. Google, June 19, 2025. <https://developers.google.com/optimization/routing/>.
+- Furnon, Vincent, and Laurent Perron. *OR-Tools*. Version 9.14. Google, June 19, 2025. <https://developers.google.com/optimization/routing/>.
 - Gaines, Helen Fouché. *Elementary Cryptanalysis*. Boston: American Photographic Publishing Co., 1939. Project Gutenberg, 2025. <https://www.gutenberg.org/ebooks/75074>.
 - Michel, Jean‑Baptiste, Yuan Kui Shen, Aviva Presser Aiden, et al. "Quantitative Analysis of Culture Using Millions of Digitized Books." *Science* 331, no. 6014 (2011): 176–82. <https://doi.org/10.1126/science.1199644>.
 - Morland, Sir Samuel. *A New Method of Cryptography*. 1666. Early English Books, 1641–1700. Internet Archive. Accessed September 21, 2025. <https://archive.org/details/bim_early-english-books-1641-1700_a-new-method-of-cryptogr_morland-sir-samuel_1666/>.

--- a/main.py
+++ b/main.py
@@ -10,10 +10,9 @@ from operator import itemgetter
 from pathlib import Path
 from typing import Sequence, TypedDict
 
-from ortools.constraint_solver import pywrapcp, routing_enums_pb2
-
 from decrypt import decrypt
 from ngram import NGramTable, load_tables, sliding_window
+from solvers import solve_tsp
 
 DATA_PATH = Path(__file__).parent.joinpath("data/word-list")
 
@@ -100,43 +99,6 @@ def score_sequence(text: Sequence[str], m: int) -> float:
                 total += value
 
     return total / m / 2
-
-
-def solve_tsp(cost: dict[tuple[int, int], int], num_columns: int) -> list[int]:
-    n = num_columns
-
-    manager = pywrapcp.RoutingIndexManager(n + 1, 1, n)
-    routing = pywrapcp.RoutingModel(manager)
-
-    def distance_callback(i: int, j: int) -> int:
-        u = manager.IndexToNode(i)
-        v = manager.IndexToNode(j)
-
-        if v == n or u == n:
-            return 0
-        else:
-            return cost[u, v]
-
-    transit_callback_index = routing.RegisterTransitCallback(distance_callback)
-    routing.SetArcCostEvaluatorOfAllVehicles(transit_callback_index)
-
-    search_parameters = pywrapcp.DefaultRoutingSearchParameters()
-    search_parameters.first_solution_strategy = (
-        routing_enums_pb2.FirstSolutionStrategy.PATH_CHEAPEST_ARC
-    )
-
-    solution = routing.SolveWithParameters(search_parameters)
-    if not solution:
-        return []
-
-    index = routing.Start(0)
-    result = [manager.IndexToNode(index)]
-    while not routing.IsEnd(index):
-        index = solution.Value(routing.NextVar(index))
-        result.append(manager.IndexToNode(index))
-
-    assert len(result) == num_columns + 2
-    return result[1:-1]
 
 
 def main() -> None:

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ from typing import Sequence, TypedDict
 
 from decrypt import decrypt
 from ngram import NGramTable, load_tables, sliding_window
-from solvers import solve_tsp
+from solvers import solve_tsp_routing
 
 DATA_PATH = Path(__file__).parent.joinpath("data/word-list")
 
@@ -49,7 +49,7 @@ def find_best_key(
     }
     max_score = max(all_score.values())
     cost = {key: -int((val - max_score) * 1_000) for key, val in all_score.items()}
-    path = solve_tsp(cost, num_columns)
+    path = solve_tsp_routing(cost, num_columns)
 
     rows = list(pairwise(path))
     mean_score = sum(all_score[i, j] for i, j in rows) / len(rows)

--- a/main.py
+++ b/main.py
@@ -98,9 +98,10 @@ def score_sequence(text: Sequence[str], m: int) -> float:
     for n in (3, 5):
         log_obs_exp = context.tables[n]
         for ngram in sliding_window(text, n):
-            value = log_obs_exp[ngram]
-            if not math.isnan(value):
-                total += value
+            if ngram in log_obs_exp:
+                value = log_obs_exp[ngram]
+                if not math.isnan(value):
+                    total += value
 
     return total / m / 2
 

--- a/ngram.py
+++ b/ngram.py
@@ -32,7 +32,10 @@ class NGramTable(Mapping[NGram, float]):
         return 26**self._n
 
     def __getitem__(self, key: NGram) -> float:
-        return self._data[encode(key)]
+        try:
+            return self._data[encode(key)]
+        except IndexError as e:
+            raise KeyError(key) from e
 
     def __iter__(self) -> Iterator[NGram]:
         return itertools.product(string.ascii_uppercase, repeat=self._n)

--- a/solvers.py
+++ b/solvers.py
@@ -1,7 +1,7 @@
 from ortools.constraint_solver import pywrapcp, routing_enums_pb2
 
 
-def solve_tsp(cost: dict[tuple[int, int], int], num_columns: int) -> list[int]:
+def solve_tsp_routing(cost: dict[tuple[int, int], int], num_columns: int) -> list[int]:
     n = num_columns
 
     manager = pywrapcp.RoutingIndexManager(n + 1, 1, n)

--- a/solvers.py
+++ b/solvers.py
@@ -1,0 +1,38 @@
+from ortools.constraint_solver import pywrapcp, routing_enums_pb2
+
+
+def solve_tsp(cost: dict[tuple[int, int], int], num_columns: int) -> list[int]:
+    n = num_columns
+
+    manager = pywrapcp.RoutingIndexManager(n + 1, 1, n)
+    routing = pywrapcp.RoutingModel(manager)
+
+    def distance_callback(i: int, j: int) -> int:
+        u = manager.IndexToNode(i)
+        v = manager.IndexToNode(j)
+
+        if v == n or u == n:
+            return 0
+        else:
+            return cost[u, v]
+
+    transit_callback_index = routing.RegisterTransitCallback(distance_callback)
+    routing.SetArcCostEvaluatorOfAllVehicles(transit_callback_index)
+
+    search_parameters = pywrapcp.DefaultRoutingSearchParameters()
+    search_parameters.first_solution_strategy = (
+        routing_enums_pb2.FirstSolutionStrategy.PATH_CHEAPEST_ARC
+    )
+
+    solution = routing.SolveWithParameters(search_parameters)
+    if not solution:
+        return []
+
+    index = routing.Start(0)
+    result = [manager.IndexToNode(index)]
+    while not routing.IsEnd(index):
+        index = solution.Value(routing.NextVar(index))
+        result.append(manager.IndexToNode(index))
+
+    assert len(result) == num_columns + 2
+    return result[1:-1]

--- a/solvers.py
+++ b/solvers.py
@@ -1,9 +1,11 @@
 import itertools
+from typing import Callable
 
 from ortools.constraint_solver import pywrapcp, routing_enums_pb2
 from ortools.sat.python import cp_model
 
 Arc = tuple[int, int]
+Solver = Callable[[dict[Arc, int], int], list[int]]
 
 
 def solve_tsp_routing(cost: dict[Arc, int], num_columns: int) -> list[int]:

--- a/solvers.py
+++ b/solvers.py
@@ -1,7 +1,12 @@
+import itertools
+
 from ortools.constraint_solver import pywrapcp, routing_enums_pb2
+from ortools.sat.python import cp_model
+
+Arc = tuple[int, int]
 
 
-def solve_tsp_routing(cost: dict[tuple[int, int], int], num_columns: int) -> list[int]:
+def solve_tsp_routing(cost: dict[Arc, int], num_columns: int) -> list[int]:
     n = num_columns
 
     manager = pywrapcp.RoutingIndexManager(n + 1, 1, n)
@@ -36,3 +41,59 @@ def solve_tsp_routing(cost: dict[tuple[int, int], int], num_columns: int) -> lis
 
     assert len(result) == num_columns + 2
     return result[1:-1]
+
+
+def solve_tsp_cp_sat(cost: dict[Arc, int], num_columns: int) -> list[int]:
+    depot = num_columns
+    n = num_columns + 1
+    if n < 2:
+        raise ValueError("Need at least two nodes")
+
+    # Add depot to cost matrix
+    full_cost = {
+        (i, j): cost.get((i, j), 1_000_000)
+        for i, j in itertools.permutations(range(num_columns), 2)
+    }
+    for i in range(n):
+        full_cost[i, depot] = 0
+        full_cost[depot, i] = 0
+
+    model = cp_model.CpModel()
+
+    # Binary arc variables
+    x: dict[Arc, cp_model.IntVar] = {}
+    for i, j in itertools.permutations(range(n), 2):
+        x[(i, j)] = model.NewBoolVar(f"x_{i}_{j}")
+
+    # Degree constraints
+    for i in range(n):
+        model.Add(sum(x[(i, j)] for j in range(n) if i != j) == 1)
+        model.Add(sum(x[(j, i)] for j in range(n) if i != j) == 1)
+
+    # MTZ subtour elimination
+    u = [model.NewIntVar(0, n - 1, f"u_{i}") for i in range(n)]
+    model.Add(u[depot] == 0)
+    for i, j in itertools.permutations(range(n), 2):
+        if i == depot or j == depot:
+            continue
+
+        model.Add(u[i] - u[j] + n * x[(i, j)] <= n - 1)
+
+    # Objective: minimise total cost
+    model.Minimize(sum(full_cost[(i, j)] * x[(i, j)] for (i, j) in x))
+
+    solver = cp_model.CpSolver()
+    solver.parameters.num_search_workers = 8
+    status = solver.Solve(model)
+    if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
+        raise RuntimeError("No solution found")
+
+    # Extract tour by following arcs from depot
+    tour_arcs = {i: j for (i, j), var in x.items() if solver.Value(var)}
+    ordered_nodes: list[int] = []
+    cur = depot
+    for _ in range(num_columns):
+        cur = tour_arcs[cur]
+        ordered_nodes.append(cur)
+
+    return ordered_nodes


### PR DESCRIPTION
Add CP-SAT as an alternative TSP solver to the OR-Tools Routing Library. It’s slower, but explores the search space more thoroughly. Enable it with the new `-s` option.

Other changes:
- Collect both solvers into the new `solvers` module.
- Handle out-of-bounds keys in `find_best_key`.